### PR TITLE
Update Poll Account When Initializing a Candidate

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -30,6 +30,8 @@ pub mod voting {
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_name = candidate_name;
         candidate.candidate_votes = 0;
+        let poll = &mut ctx.accounts.poll;
+        poll.candidate_amount += 1;
         Ok(())
     }
 

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -51,7 +51,13 @@ describe("Voting", () => {
       "Blue",
       new anchor.BN(1),
     ).rpc();
-
+    const [pollAddress] = PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8)],
+      votingProgram.programId
+    );
+    const poll = await votingProgram.account.poll.fetch(pollAddress);
+    expect(poll.candidateAmount.toNumber()).toBe(2);
+    
     const [pinkAddress] = PublicKey.findProgramAddressSync(
       [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Pink")],
       votingProgram.programId,


### PR DESCRIPTION
Fixes the issue where new candidates weren't updating the poll account by ensuring the candidate count is properly incremented when initializing new candidates.

Registered email address : vijaykv2228@gmail.com. 
 This pull request was created for https://app.gib.work/bounties/4c12a869-cebb-4513-a19b-beefdd8bcc80 in an attempt to solve a bounty #1 . Payment for the bounty is immediately sent to the contributor after merge.